### PR TITLE
Refactor puzzle state to seperate function from redux state

### DIFF
--- a/src/app/containers/GridContainer.js
+++ b/src/app/containers/GridContainer.js
@@ -2,10 +2,11 @@ import { connect } from 'react-redux';
 import { moveTile } from '../actions/gameActions';
 import React from 'react';
 import Grid from '../components/Grid.js';
-import { getPuzzle } from '../selectors';
+import { getCheckMove } from '../selectors';
 
 const mapStateToProps = (state, { width, height }) => {
-    return { puzzle: getPuzzle(state), width, height };
+    const { board, size } = state.game;
+    return { board, size , width, height, checkMove: getCheckMove(state) };
 };
 
 // count on conncet to auto bind the action creator to dispatch
@@ -15,19 +16,17 @@ const mapDispatchToProps = { moveTile };
 // 1) it map from state into grid props including handling a null puzzle.
 // 2) it create an onTileClicked action which check for move validity
 //    and fires a moveTile action with the right property when it is
-export const GridContainer = ({ puzzle, height, width, moveTile }) => {
-    let tiles = [null];
-    let columns = 1;
-    if (puzzle) {
-        tiles = puzzle.board;
-        columns = puzzle.size;
+const GridContainer = ({ board, size, height, width, checkMove, moveTile }) => {
+    if (!board) {
+        board=[null];
+        size=1;
     }
 
     return (
-        <Grid tiles={tiles} columns={columns}
+        <Grid tiles={board} columns={size}
             height={height} width={width}
             onTileClicked={(tilePos) => {
-                const to = puzzle.checkMove(tilePos);
+                const to = checkMove(tilePos);
                 if (to >= 0) // only execute valid moves
                     moveTile(tilePos, to);
             }}

--- a/src/app/reducers/gameReducer.js
+++ b/src/app/reducers/gameReducer.js
@@ -2,61 +2,69 @@ import Puzzle from '../utils/puzzle.js';
 import { RESET_BOARD, MOVE_TILE, UNDO_MOVE, NEW_GAME } from '../actions/gameActions';
 import { createSelector } from 'reselect';
 
-function newPuzzle(puzzle) {
+function newPuzzle(size, board) {
     return {
-        puzzle,
+        board,
+        size,
         moves: [],
-        originalPuzzle: puzzle
+        originalBoard: board
     };
 }
 
 // private selectors, used by reducer and public selectors
-export const getPuzzle = (state) => state.puzzle;
+export const getPuzzle = createSelector((state) => state.size, (size) => new Puzzle(size));
 export const anyMovesDone = (state) => state.moves.length > 0;
-export const isSolved = createSelector(getPuzzle,
-    (puzzle) => (puzzle?puzzle.isSolved():false));
+export const isSolved = createSelector(
+    [getPuzzle, (state) => state.board],
+    (puzzle, board) => (board?puzzle.isSolved(board):false)
+);
+const getBoard = (state) => state.board;
+export const getCheckMove = createSelector(
+    [getPuzzle, getBoard],
+    (puzzle, board) => (pos) => puzzle.checkMove(board,pos)
+);
 
-export default (state = newPuzzle(null), action) => {
+export default (state = newPuzzle(1, null), action) => {
     switch (action.type) {
     case NEW_GAME:
-        return newPuzzle(new Puzzle(action.size));
+        return newPuzzle(action.size, new Puzzle(action.size).createBoard());
 
     case RESET_BOARD: {
-        if (!state.puzzle || isSolved(state) || !anyMovesDone(state))
+        if (!state.board || isSolved(state) || !anyMovesDone(state))
             return state;
 
         return {
-            puzzle: state.originalPuzzle,
-            moves: [],
-            originalPuzzle: state.originalPuzzle
+            ...state,
+            board: state.originalBoard,
+            moves: []
         };
     }
 
     case MOVE_TILE: {
-        if (!state.puzzle || isSolved(state))
+        if (!state.board || isSolved(state))
             return state;
 
         const move = action.move;
-        const puzzle = state.puzzle.executeMove(move.from, move.to);
+        const board = getPuzzle(state).executeMove(state.board, move.from, move.to);
 
         return {
-            puzzle,
+            ...state,
+            board,
             moves: [ ...state.moves, move ],
-            originalPuzzle: state.originalPuzzle
         };
     }
 
     case UNDO_MOVE: {
-        if (!state.puzzle || isSolved(state) || !anyMovesDone(state))
+        if (!state.board || isSolved(state) || !anyMovesDone(state))
             return state;
 
         const moves = state.moves.slice(0);
         const { from, to } = moves.pop();
 
         return {
-            puzzle: state.puzzle.executeMove(to, from),
+            ...state,
+            board: getPuzzle(state).executeMove(state.board,to, from),
             moves,
-            originalPuzzle: state.originalPuzzle
         };
     }
 

--- a/src/app/reducers/gameReducer.js
+++ b/src/app/reducers/gameReducer.js
@@ -2,7 +2,8 @@ import Puzzle from '../utils/puzzle.js';
 import { RESET_BOARD, MOVE_TILE, UNDO_MOVE, NEW_GAME } from '../actions/gameActions';
 import { createSelector } from 'reselect';
 
-function newPuzzle(size, board) {
+function newPuzzle(size) {
+    const board=new Puzzle(size).createBoard();
     return {
         board,
         size,
@@ -24,13 +25,13 @@ export const getCheckMove = createSelector(
     (puzzle, board) => (pos) => puzzle.checkMove(board,pos)
 );
 
-export default (state = newPuzzle(1, null), action) => {
+export default (state = newPuzzle(1), action) => {
     switch (action.type) {
     case NEW_GAME:
-        return newPuzzle(action.size, new Puzzle(action.size).createBoard());
+        return newPuzzle(action.size);
 
     case RESET_BOARD: {
-        if (!state.board || isSolved(state) || !anyMovesDone(state))
+        if (isSolved(state) || !anyMovesDone(state))
             return state;
 
         return {
@@ -41,7 +42,7 @@ export default (state = newPuzzle(1, null), action) => {
     }
 
     case MOVE_TILE: {
-        if (!state.board || isSolved(state))
+        if (isSolved(state))
             return state;
 
         const move = action.move;
@@ -55,7 +56,7 @@ export default (state = newPuzzle(1, null), action) => {
     }
 
     case UNDO_MOVE: {
-        if (!state.board || isSolved(state) || !anyMovesDone(state))
+        if (isSolved(state) || !anyMovesDone(state))
             return state;
 
         const moves = state.moves.slice(0);

--- a/src/app/reducers/modalReducer.js
+++ b/src/app/reducers/modalReducer.js
@@ -3,7 +3,13 @@ import { OPEN_NEW_GAME_MODAL, CLOSE_NEW_GAME_MODAL,
 import { NEW_GAME } from '../actions/gameActions';
 
 
-export default (state = {showInit: true}, action) => {
+const INIT_STATE={
+    showInit: true,
+    showNewGame: false,
+    canShowSolved: false
+};
+
+export default (state = INIT_STATE, action) => {
     switch (action.type) {
 
     case OPEN_NEW_GAME_MODAL:

--- a/src/app/selectors/index.js
+++ b/src/app/selectors/index.js
@@ -2,4 +2,4 @@ import * as FromGame from '../reducers/gameReducer';
 
 export const anyMovesDone = (state) => FromGame.anyMovesDone(state.game);
 export const isSolved = (state) => FromGame.isSolved(state.game);
-export const getPuzzle = (state) => FromGame.getPuzzle(state.game);
+export const getCheckMove = (state) => FromGame.getCheckMove(state.game);

--- a/src/app/utils/puzzle.js
+++ b/src/app/utils/puzzle.js
@@ -1,17 +1,11 @@
 export const EMPTY_TILE = null;
 
 export default class Puzzle {
-    constructor (size, board) {
+    constructor (size) {
         this.size = size;
-        if (board === undefined)
-            board = createSolvableBoard(size);
-
-        this.board = board;
     }
 
-    isSolved () {
-        const board = this.board;
-
+    isSolved (board) {
         for (let i = 0; i < board.length - 1; i++) {
             if (board[i] !== (i + 1))
                 return false;
@@ -25,22 +19,22 @@ export default class Puzzle {
 	 * the pos of the empty tile so they could be replaced.
 	 * O/W returns -1.
 	 */
-    checkMove (pos) {
+    checkMove (board, pos) {
         const row = Math.floor(pos / this.size);
         const col = pos % this.size;
         let newPos;
 
-        if (row > 0 && this.board[newPos = this.index(row - 1, col)] === EMPTY_TILE)
+        if (row > 0 && board[newPos = this.index(row - 1, col)] === EMPTY_TILE)
             return newPos;
 
-        if (row < this.size - 1 && this.board[newPos = this.index(row + 1, col)] === EMPTY_TILE)
+        if (row < this.size - 1 && board[newPos = this.index(row + 1, col)] === EMPTY_TILE)
             return newPos;
 
 
-        if (col > 0 && this.board[newPos = this.index(row, col - 1)] === EMPTY_TILE)
+        if (col > 0 && board[newPos = this.index(row, col - 1)] === EMPTY_TILE)
             return newPos;
 
-        if (col < this.size - 1 && this.board[newPos = this.index(row, col + 1)] === EMPTY_TILE)
+        if (col < this.size - 1 && board[newPos = this.index(row, col + 1)] === EMPTY_TILE)
             return newPos;
 
         return -1;
@@ -50,79 +44,75 @@ export default class Puzzle {
         return row * this.size + col;
     }
 
-    /**
-	 * as puzzle is immutabel creates a new Puzzle where the tile in
-	 * oldPos is replaced by the tile in newPos
-	 */
-    executeMove (from, to) {
-        const oldBoard = this.board;
-        const newBoard = oldBoard.slice(0);
 
-        newBoard[to] = oldBoard[from];
-        newBoard[from] = oldBoard[to];
-
-        return new Puzzle(this.size, newBoard);
+    executeMove (board, from, to) {
+        const newBoard = board.slice(0);
+        newBoard[to] = board[from];
+        newBoard[from] = board[to];
+        return newBoard;
     }
-}
 
-function createSolvableBoard (edgeSize) {
-    let board;
+    createBoard () {
+        if (this.size<2)
+            return [EMPTY_TILE];
 
-    do {
-        board = createBoard(edgeSize * edgeSize);
-    } while (!isSolvable(board, edgeSize));
+        let board=range(1,this.size*this.size);
+        board.push(EMPTY_TILE);
+        board=shuffle(board);
 
-    return board;
-}
+        if (!this.isSolved(board) && this._isSolvable(board))
+            return board;
 
-function isSolvable (board, size) {
-    let inversions = 0;
+        return this.createBoard();
+    }
 
-    for (let i = 0; i < board.length; i++) {
-        if (board[i] === EMPTY_TILE)
-            continue;
+    _isSolvable (board) {
+        let inversions = 0;
 
-        for (let j = i + 1; j < board.length; j++) {
-            if (board[j] !== EMPTY_TILE && board[i] > board[j])
-                inversions++;
+        for (let i = 0; i < board.length; i++) {
+            if (board[i] === EMPTY_TILE)
+                continue;
+
+            for (let j = i + 1; j < board.length; j++) {
+                if (board[j] !== EMPTY_TILE && board[i] > board[j])
+                    inversions++;
+            }
         }
 
+        let parity = 0;
+        if (this.size % 2 === 0) {
+            // for even N the algorithm is more complex
+            // find empty tile and check if its an even or odd row from the bottom
+            let i;
+            for (i = 0; i < board.length; i++)
+                if (board[i] === EMPTY_TILE)
+                    break;
+
+            // calculate row
+            const row = Math.floor(i / this.size);
+            parity = (row + 1) % 2;
+        }
+
+        return inversions % 2 === parity;
     }
 
-    let parity = 0;
-    if (size % 2 === 0) {
-        // for even N the algorithm is more complex
-        // find empty tile and check if its an even or odd row from the bottom
-        let i;
-        for (i = 0; i < board.length; i++)
-            if (board[i] === EMPTY_TILE)
-                break;
-
-        // calculate row
-        const row = Math.floor(i / size);
-        parity = (row + 1) % 2;
-    }
-
-    return inversions % 2 === parity;
 }
 
-function createBoard (size) {
-    const board = new Array(size).fill(0);
-    board.forEach((e, i, arr) => { arr[i] = i; });
-    board[0] = EMPTY_TILE;
+function shuffle(arr) {
+    arr=arr.slice(0);
+    const random=(max) => Math.floor(Math.random() * Math.floor(max));
 
-    let n = size;
+    let n = arr.length;
     while (n > 1) {
         const r = random(n--);
-        const tmp = board[r];
-        board[r] = board[n];
-        board[n] = tmp;
+        const tmp = arr[r];
+        arr[r] = arr[n];
+        arr[n] = tmp;
     }
 
-    return board;
+    return arr;
 }
 
-function random (max) {
-    return Math.floor(Math.random() * Math.floor(max));
+function range(start, end) {
+    return [...Array(end-start).keys()].map(i => i + start);
 }
-

--- a/test/app/IntegrationTests.test.js
+++ b/test/app/IntegrationTests.test.js
@@ -1,4 +1,4 @@
-import Puzzle, { EMPTY_TILE } from '../../src/app/utils/puzzle';
+import { EMPTY_TILE } from '../../src/app/utils/puzzle';
 import createStore from '../../src/app/configureStore';
 import { mount } from 'enzyme';
 import React from 'react';
@@ -14,10 +14,9 @@ const TILES=[1, 2, 3, 4, 5, 6 ,7 , EMPTY_TILE, 8];
 
 // create a redux state with an initalized game
 function newGameState() {
-    const puzzle=new Puzzle(3,TILES);
     const state=rootReducer(undefined, newGame(3));
-    state.game.puzzle=puzzle;
-    state.game.originalPuzzle=puzzle;
+    state.game.board=TILES;
+    state.game.originalBoard=TILES;
 
     return state;
 }

--- a/test/app/containers/GridContainer.test.js
+++ b/test/app/containers/GridContainer.test.js
@@ -6,16 +6,14 @@ import { moveTile } from '../../../src/app/actions/gameActions';
 
 const mockStore = configureMockStore();
 
-const getStore = (size, board, checkMove=() => -1) => {
-    return mockStore({
+const getStore = (size, board) => {
+    const state = {
         game: {
-            puzzle: board?{
-                board,
-                size,
-                checkMove
-            }: null
+            board,
+            size
         }
-    });
+    };
+    return mockStore(state);
 };
 
 describe('<GridContainer>', () => {
@@ -42,23 +40,19 @@ describe('<GridContainer>', () => {
 
     it('should invoke MOVE_ACTION when and only when the right tile is clicked', () => {
         const dispatch=jest.fn();
-        const checkMove=jest.fn();
-        const store=getStore(2, [1, 2, 3, null],checkMove);
+        const board=[1, 2, 3, null];
+        const store=getStore(2,board);
         store.dispatch=dispatch;
 
         const gcWrapper = mount(<GridContainer height={30} width={40} store={store} />);
         const onTileClicked=gcWrapper.find('Grid').prop('onTileClicked');
 
         // checkMove fails
-        checkMove.mockReturnValueOnce(-1);
-        onTileClicked(1);
-        expect(checkMove).toBeCalledWith(1);
+        onTileClicked(0);
         expect(dispatch).not.toBeCalled();
 
         // check moves succeeds
-        checkMove.mockReturnValueOnce(3);
         onTileClicked(2);
-        expect(checkMove).toBeCalledWith(2);
         expect(dispatch).toBeCalledWith(moveTile(2,3));
     });
 

--- a/test/app/containers/SolvedModalContainer.test.js
+++ b/test/app/containers/SolvedModalContainer.test.js
@@ -12,7 +12,7 @@ const getStore = (canShowSolved, isSolved) => {
             canShowSolved
         },
         game: {
-            puzzle: { isSolved }
+            board: isSolved?[1,2,3, null]:[1,3,2,null]
         }
     });
 };
@@ -20,25 +20,25 @@ const getStore = (canShowSolved, isSolved) => {
 describe('<SolvedModalContainer>', () => {
     it('should render when puzzle is solved and not closed', () => {
         const smWrapper=shallow(<SolvedModalContainer store=
-            {getStore(true, () => true)}/>).dive().dive();
+            {getStore(true, true)}/>).dive().dive();
         expect(smWrapper.prop('show')).toBe(true);
     });
 
     it('should not render when puzzle is not solved', () => {
         const smWrapper=shallow(<SolvedModalContainer store=
-            {getStore(true, () => false)}/>).dive().dive();
+            {getStore(true, false)}/>).dive().dive();
         expect(smWrapper.prop('show')).toBe(false);
     });
 
     it('should not render after close', () => {
         const smWrapper=shallow(<SolvedModalContainer store=
-            {getStore(false, () => true)}/>).dive().dive();
+            {getStore(false, true)}/>).dive().dive();
         expect(smWrapper.prop('show')).toBe(false);
     });
 
     it('should close without further action when "No" is clicked', () => {
         const dispatch=jest.fn();
-        const store=getStore(true, () => true);
+        const store=getStore(true, true);
         store.dispatch=dispatch;
         const smWrapper=mount(<SolvedModalContainer store=
             {store}/>);
@@ -49,7 +49,7 @@ describe('<SolvedModalContainer>', () => {
 
     it('should invoke newGameModal when "Yes" is clicked', () => {
         const dispatch=jest.fn();
-        const store=getStore(true, () => true);
+        const store=getStore(true, true);
         store.dispatch=dispatch;
         const smWrapper=mount(<SolvedModalContainer store={store}/>);
 

--- a/test/app/reducers/gameReducer.test.js
+++ b/test/app/reducers/gameReducer.test.js
@@ -4,10 +4,10 @@ import * as Action from '../../../src/app/actions/gameActions';
 
 const BOARD1 = [1, 2, 3, 4, 5, 6, 7, EMPTY_TILE, 8];
 const INITAL_STATE = {
-    originalBoard: null,
+    originalBoard: [EMPTY_TILE],
     moves: [],
     size: 1,
-    board: null
+    board: [EMPTY_TILE]
 };
 
 describe(' Game Reducer', () => {
@@ -132,8 +132,8 @@ describe('isSolved selector', () => {
         })).toBe(true);
     });
 
-    it('should return false on uninitialized array', () => {
-        expect(isSolved(reducer(undefined, {}))).toBe(false);
+    it('should return valid boolean on inital state (before new game)', () => {
+        expect(typeof isSolved(reducer(undefined, {}))).toBe('boolean');
     });
 
     it('should not invoke isSolved() when state has not changed', () => {

--- a/test/app/reducers/gameReducer.test.js
+++ b/test/app/reducers/gameReducer.test.js
@@ -1,12 +1,13 @@
-import reducer, { anyMovesDone, isSolved } from '../../../src/app/reducers/gameReducer';
-import Puzzle, { EMPTY_TILE } from '../../../src/app/utils/puzzle';
+import reducer, { anyMovesDone, isSolved, getPuzzle, getCheckMove } from '../../../src/app/reducers/gameReducer';
+import { EMPTY_TILE } from '../../../src/app/utils/puzzle';
 import * as Action from '../../../src/app/actions/gameActions';
 
-const PUZZLE1 = new Puzzle(3, [1, 2, 3, 4, 5, 6, 7, EMPTY_TILE, 8]);
+const BOARD1 = [1, 2, 3, 4, 5, 6, 7, EMPTY_TILE, 8];
 const INITAL_STATE = {
-    originalPuzzle: null,
+    originalBoard: null,
     moves: [],
-    puzzle: null
+    size: 1,
+    board: null
 };
 
 describe(' Game Reducer', () => {
@@ -16,24 +17,26 @@ describe(' Game Reducer', () => {
 
     it('should handle MOVE_TILE', () => {
         expect(reducer({
-            originalPuzzle: PUZZLE1,
+            originalBoard: BOARD1,
+            size: 3,
             moves: [],
-            puzzle: PUZZLE1
+            board: BOARD1
         }, Action.moveTile(6, 7))).toEqual({
-            originalPuzzle: PUZZLE1,
+            originalBoard: BOARD1,
             moves: [{ from: 6, to: 7 }],
-            puzzle: new Puzzle(3, [1, 2, 3, 4, 5, 6, EMPTY_TILE, 7, 8])
+            size: 3,
+            board: [1, 2, 3, 4, 5, 6, EMPTY_TILE, 7, 8]
         });
 
         expect(reducer({
-            originalPuzzle: PUZZLE1,
+            originalBoard: BOARD1,
             moves: [{ from: 6, to: 7 }],
-            puzzle: new Puzzle(3, [1, 2, 3, 4, 5, 6, EMPTY_TILE, 7, 8])
+            board: [1, 2, 3, 4, 5, 6, EMPTY_TILE, 7, 8]
         }
             , Action.moveTile(3, 6))).toEqual({
-            originalPuzzle: PUZZLE1,
+            originalBoard: BOARD1,
             moves: [{ from: 6, to: 7 }, { from: 3, to: 6 }],
-            puzzle: new Puzzle(3, [1, 2, 3, EMPTY_TILE, 5, 6, 4, 7, 8])
+            board: [1, 2, 3, EMPTY_TILE, 5, 6, 4, 7, 8]
         });
 
         expect(reducer(undefined, Action.moveTile(6, 7))).toEqual(INITAL_STATE);
@@ -42,43 +45,46 @@ describe(' Game Reducer', () => {
     it('should handle NEW_GAME', () => {
         let newState = reducer(undefined, Action.newGame(2));
         expect(newState.moves).toEqual([]);
-        expect(newState.puzzle).toEqual(newState.originalPuzzle);
-        expect(newState.puzzle.size).toBe(2);
-        expect(newState.puzzle.board.sort()).toEqual([1, 2, 3, EMPTY_TILE]);
-
+        expect(newState.size).toBe(2);
+        expect(newState.board.sort()).toEqual([1, 2, 3, EMPTY_TILE]);
+        expect(newState.originalBoard).toEqual(newState.board);
 
         newState = reducer({
-            puzzle: new Puzzle(3, [1, 2, 3, EMPTY_TILE, 5, 6, 4, 7, 8]),
+            board: [1, 2, 3, EMPTY_TILE, 5, 6, 4, 7, 8],
             moves: [{ from: 6, to: 7 }, { from: 3, to: 6 }],
-            originalPuzzle: PUZZLE1
+            size: 3,
+            originalBoard: BOARD1
         }, Action.newGame(1));
         expect(newState.moves).toEqual([]);
-        expect(newState.originalPuzzle).toEqual(new Puzzle(1));
-        expect(newState.puzzle).toEqual(newState.originalPuzzle);
+        expect(newState.originalBoard).toEqual([null]);
+        expect(newState.board).toEqual(newState.originalBoard);
     });
 
     it('should handle UNDO', () => {
         expect(reducer(undefined, Action.undoMove)).toEqual(INITAL_STATE);
 
-        const puzzle = new Puzzle(2, [1, 3, 2, EMPTY_TILE]);
+        const board = [1, 3, 2, EMPTY_TILE];
         const currentState = {
-            originalPuzzle: puzzle,
-            puzzle: puzzle,
+            originalBoard: board,
+            board,
+            size: 2,
             moves: []
         };
         expect(reducer(currentState, Action.undoMove())).toEqual(currentState);
 
         currentState.moves = [{ from: 3, to: 2 }];
         expect(reducer(currentState, Action.undoMove())).toEqual({
-            originalPuzzle: puzzle,
-            puzzle: new Puzzle(2, [1, 3, EMPTY_TILE, 2]),
+            originalBoard: board,
+            board: [1, 3, EMPTY_TILE, 2],
+            size: 2,
             moves: []
         });
 
         currentState.moves = [{ from: 0, to: 2 }, { from: 3, to: 2 }];
         expect(reducer(currentState, Action.undoMove())).toEqual({
-            originalPuzzle: puzzle,
-            puzzle: new Puzzle(2, [1, 3, EMPTY_TILE, 2]),
+            originalBoard: board,
+            board: [1, 3, EMPTY_TILE, 2],
+            size: 2,
             moves: [{ from: 0, to: 2 }]
         });
 
@@ -89,22 +95,24 @@ describe(' Game Reducer', () => {
 
         // 1 3
         // 2 null
-        const originalPuzzle = new Puzzle(2, [1, 3, 2, EMPTY_TILE]);
+        const originalBoard = [1, 3, 2, EMPTY_TILE];
         const currentState = {
-            originalPuzzle,
-            puzzle: originalPuzzle,
+            originalBoard,
+            board: originalBoard,
+            size:2,
             moves: []
         };
         expect(reducer(currentState, Action.resetBoard())).toEqual(currentState);
 
 
         currentState.moves = [{ from: 2, to: 3 }, { from: 0, to: 2 }];
-        currentState.puzzle = new Puzzle(2, [EMPTY_TILE, 3, 1, 2]);
+        currentState.board = [EMPTY_TILE, 3, 1, 2];
 
         expect(reducer(currentState, Action.resetBoard())).toEqual({
-            originalPuzzle,
+            originalBoard,
             moves: [],
-            puzzle: originalPuzzle
+            size:2,
+            board: originalBoard
         });
     });
 });
@@ -112,13 +120,15 @@ describe(' Game Reducer', () => {
 describe('isSolved selector', () => {
     it('should return false on unsolved puzzle', () => {
         expect(isSolved({
-            puzzle: new Puzzle(2, [1, 2, EMPTY_TILE, 3])
+            board: [1, 2, EMPTY_TILE, 3],
+            size: 2
         })).toBe(false);
     });
 
     it('should return true on solved puzzle', () => {
         expect(isSolved({
-            puzzle: new Puzzle(2, [1, 2, 3, EMPTY_TILE])
+            board: [1, 2, 3, EMPTY_TILE],
+            size:2
         })).toBe(true);
     });
 
@@ -127,17 +137,24 @@ describe('isSolved selector', () => {
     });
 
     it('should not invoke isSolved() when state has not changed', () => {
-        let puzzle=new Puzzle(2,[1,EMPTY_TILE,3,null]);
+        const state={
+            board: [1,EMPTY_TILE,3,null],
+            size: 2
+        };
+
         const mockIsSolved=jest.fn();
-        puzzle.isSolved=mockIsSolved;
-        isSolved({puzzle});
-        isSolved({puzzle}); // call twice      
+        getPuzzle(state).isSolved=mockIsSolved;
+        isSolved(state);
+        isSolved(state); // call twice      
         expect(mockIsSolved.mock.calls.length).toBe(1);
 
         // call with a new equiavlent puzzle instance should increase the count
-        puzzle=new Puzzle(2,[1,EMPTY_TILE,3,null]);
-        puzzle.isSolved=mockIsSolved;
-        isSolved({puzzle});
+        const state2={
+            board: [1,EMPTY_TILE,3,null],
+            size: 2
+        };
+        getPuzzle(state2).isSolved=mockIsSolved;
+        isSolved(state2);
         expect(mockIsSolved.mock.calls.length).toBe(2);
     });
 });
@@ -154,5 +171,60 @@ describe('any moves done selector', () => {
     it('should return true on a game with moves', () => {
         const state = reducer(reducer(undefined, Action.newGame(2)), Action.moveTile(0, 1));
         expect(anyMovesDone(state));
+    });
+});
+
+
+describe('getCheckMove', () => {
+    it('should return a function', () => {
+        expect(getCheckMove({size:2, board:[1,2,3,null]})).toBeInstanceOf(Function);
+    });
+
+    it('should return a function that properly tests moves a board of 2x2', () => {
+        expect(getCheckMove({size:2, board:[1,2,3,null]})(0)).toBe(-1);
+        expect(getCheckMove({size:2, board:[1,2,3,null]})(2)).toBe(3);
+        expect(getCheckMove({size:2, board:[1,2,3,null]})(1)).toBe(3);
+    });
+
+    it('should return a function that properly tests moves a board of 3x3', () => {
+        // 012
+        // 345
+        // 678 
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(1)).toBe(4);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(3)).toBe(4);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(7)).toBe(4);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(0)).toBe(-1);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(2)).toBe(-1);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(6)).toBe(-1);
+        expect(getCheckMove({size:3, board:[1,2,3,4,null,5,6,7,8]})(8)).toBe(-1);
+    });
+
+    it('should return the same function when board and size dont change', () => {
+        const board=[1,2,3,null];
+        expect(getCheckMove({size:2, board })).toBe(getCheckMove({size:2, board}));
+    });
+
+    it('should return the a d function when board is not the same or size changes', () => {
+        expect(getCheckMove({size:2, board:[1,2,3,null]})).not.toBe(
+            getCheckMove({size:2, board:[1,3,2,null]}));
+
+        const board=[1,2,3,null];
+        expect(getCheckMove({size:2, board})).not.toBe(
+            getCheckMove({size:3, board}));
+    });
+});
+
+describe('getPuzzle selector', () => {
+    it('should return the same object when size dont change', () => {
+        expect(getPuzzle({size:1, board:null})).toBe(getPuzzle({size:1,board:[null]}));
+    });
+
+    it('should return a puzzle with the proper size' , () => {
+        expect(getPuzzle({size:2}).size).toBe(2);
+        expect(getPuzzle({size:3}).size).toBe(3);
+    });
+
+    it('should return a valid puzzle on init , with size 1', () => {
+        expect(getPuzzle(reducer(undefined,{})).size).toBe(1);
     });
 });

--- a/test/app/utils/puzzle.test.js
+++ b/test/app/utils/puzzle.test.js
@@ -1,18 +1,14 @@
 import Puzzle, { EMPTY_TILE } from '../../../src/app/utils/puzzle';
 
 describe('Puzzle', () => {
-    it('create a puzzle from a given array', () => {
-        const b = [1, 2, 3, 4, 5, 6, 7, 8, EMPTY_TILE];
-        const p = new Puzzle(3, b);
-        expect(p.board).toEqual(b);
-        expect(p.size).toBe(3);
+
+    it('create a puzzle of size 1', () => {
+        expect(new Puzzle(1).createBoard()).toEqual([EMPTY_TILE]);
     });
 
-    it('create a random puzzle of size 3', () => {
-        const p = new Puzzle(3);
-        const board = p.board;
-        expect(p.size).toBe(3);
-        expect(board.length).toBe(9);
+    it('create a puzzle of size 3', () => {
+        const puzzle = new Puzzle(3);
+        const board = puzzle.createBoard();
         expect(board).toContain(EMPTY_TILE);
         expect(board).toContain(1);
         expect(board).toContain(2);
@@ -25,51 +21,57 @@ describe('Puzzle', () => {
     });
 
     it('should inidcate that puzzle is solved', () => {
-        expect(new Puzzle(2, [1, 2, 3, EMPTY_TILE]).isSolved()).toBe(true);
-        expect(new Puzzle(2, [EMPTY_TILE, 1, 2, 3]).isSolved()).toBe(false);
-        expect(new Puzzle(2, [1, 3, 2, EMPTY_TILE]).isSolved()).toBe(false);
-        expect(new Puzzle(2, [1, 2, 3, 4, 5, 6, 7, 8, EMPTY_TILE]).isSolved()).toBe(true);
-        expect(new Puzzle(2, [1, 3, 2, 4, 5, 6, 7, 8, EMPTY_TILE]).isSolved()).toBe(false);
+        const puzzle2=new Puzzle(2);
+        expect(puzzle2.isSolved([1, 2, 3, EMPTY_TILE])).toBe(true);
+
+        expect(puzzle2.isSolved([EMPTY_TILE, 1, 2, 3])).toBe(false);
+        expect(puzzle2.isSolved([1, 3, 2, EMPTY_TILE])).toBe(false);
+
+        const puzzle3=new Puzzle(3);
+        expect(puzzle3.isSolved([1, 2, 3, 4, 5, 6, 7, 8, EMPTY_TILE])).toBe(true);
+        expect(puzzle3.isSolved([1, 3, 2, 4, 5, 6, 7, 8, EMPTY_TILE])).toBe(false);
     });
 
     it('should checkMove properly', () => {
         // 0 1
         // 2 3
-        expect(new Puzzle(2, [0, 1, 2, EMPTY_TILE]).checkMove(2)).toBe(3);
-        expect(new Puzzle(2, [0, 1, 2, EMPTY_TILE]).checkMove(1)).toBe(3);
-        expect(new Puzzle(2, [0, 1, 2, EMPTY_TILE]).checkMove(0)).toBe(-1);
-        expect(new Puzzle(2, [EMPTY_TILE, 1, 2, 3]).checkMove(1)).toBe(0);
-        expect(new Puzzle(2, [EMPTY_TILE, 1, 2, 3]).checkMove(2)).toBe(0);
-        expect(new Puzzle(2, [EMPTY_TILE, 1, 2, 3]).checkMove(3)).toBe(-1);
+        const puzzle2=new Puzzle(2);
+        expect(puzzle2.checkMove([0, 1, 2, EMPTY_TILE],2)).toBe(3);
+        expect(puzzle2.checkMove([0, 1, 2, EMPTY_TILE],1)).toBe(3);
+        expect(puzzle2.checkMove([0, 1, 2, EMPTY_TILE],0)).toBe(-1);
+        expect(puzzle2.checkMove([EMPTY_TILE, 1, 2, 3],1)).toBe(0);
+        expect(puzzle2.checkMove([EMPTY_TILE, 1, 2, 3],2)).toBe(0);
+        expect(puzzle2.checkMove([EMPTY_TILE, 1, 2, 3],3)).toBe(-1);
 
         // 0 1 2
         // 3 4 5
         // 6 7 8 
-        const emptyCenterPuzzle = new Puzzle(3, [0, 1, 2, 3, EMPTY_TILE, 5, 6, 7, 8, 9]);
-        expect(emptyCenterPuzzle.checkMove(1)).toBe(4);
-        expect(emptyCenterPuzzle.checkMove(3)).toBe(4);
-        expect(emptyCenterPuzzle.checkMove(5)).toBe(4);
-        expect(emptyCenterPuzzle.checkMove(7)).toBe(4);
+        const puzzle3=new Puzzle(3);
+        const emptyCenterBoard = [0, 1, 2, 3, EMPTY_TILE, 5, 6, 7, 8, 9];
+        expect(puzzle3.checkMove(emptyCenterBoard,1)).toBe(4);
+        expect(puzzle3.checkMove(emptyCenterBoard,3)).toBe(4);
+        expect(puzzle3.checkMove(emptyCenterBoard,5)).toBe(4);
+        expect(puzzle3.checkMove(emptyCenterBoard,7)).toBe(4);
 
-        const noEmptyPuzzle = new Puzzle(3, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        expect(noEmptyPuzzle.checkMove(1)).toBe(-1);
-        expect(noEmptyPuzzle.checkMove(3)).toBe(-1);
-        expect(noEmptyPuzzle.checkMove(5)).toBe(-1);
-        expect(noEmptyPuzzle.checkMove(7)).toBe(-1);
+        const noEmptyBoard = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        expect(puzzle3.checkMove(noEmptyBoard,1)).toBe(-1);
+        expect(puzzle3.checkMove(noEmptyBoard,3)).toBe(-1);
+        expect(puzzle3.checkMove(noEmptyBoard,5)).toBe(-1);
+        expect(puzzle3.checkMove(noEmptyBoard,7)).toBe(-1);
     });
 
     it('should execute exemovecuteMove', () => {
-        const p1 = new Puzzle(2, [0, 1, 2, EMPTY_TILE]);
-        const p2 = p1.executeMove(0, 3);
+        const puzzle=new Puzzle(2);
+        const b1 = [0, 1, 2, EMPTY_TILE];
+        const b2 = puzzle.executeMove(b1, 0, 3);
 
-        expect(p2).not.toBe(p1);
-        expect(p2.board).not.toBe(p1.board);
-        expect(p2.board).toEqual([EMPTY_TILE, 1, 2, 0]);
-        expect(p1.board).toEqual([0, 1, 2, EMPTY_TILE]);
+        expect(b2).not.toBe(b1);
+        expect(b2).toEqual([EMPTY_TILE, 1, 2, 0]);
+        expect(b1).toEqual([0, 1, 2, EMPTY_TILE]);
     });
 
     it('calculate index based on row and columns', () => {
-        const p = new Puzzle(2, [0, 1, 2, EMPTY_TILE]);
+        const p = new Puzzle(2);
         expect(p.index(0, 0)).toBe(0);
         expect(p.index(0, 1)).toBe(1);
         expect(p.index(0, 2)).toBe(2);


### PR DESCRIPTION
refactoring game state so that only state and not functions are saved on the redux store.   Extract the internal state of the puzzle + its size and save directly on redux while the class remains only to provide methods to manage it.  